### PR TITLE
Update Lighthouse branch

### DIFF
--- a/lighthouse/Dockerfile.lighthouse
+++ b/lighthouse/Dockerfile.lighthouse
@@ -2,7 +2,7 @@ FROM rust:1.74.0-bullseye AS builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake clang libclang-dev protobuf-compiler bash
 ARG FEATURES
 
-RUN bash -c "git clone https://github.com/sigp/lighthouse.git && cd lighthouse && git checkout sidecar-inclusion-proof && CROSS_PROFILE=maxperf make"
+RUN bash -c "git clone https://github.com/sigp/lighthouse.git && cd lighthouse && git checkout unstable && CROSS_PROFILE=maxperf make"
 
 FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y software-properties-common && add-apt-repository ppa:rmescandon/yq


### PR DESCRIPTION
Addresses #16.

Update Lighthouse branch to `unstable` as the `sidecar-inclusion-proof` branch has just been merged.